### PR TITLE
add exit data, fix room data bugs

### DIFF
--- a/data/exits/bathroom.json
+++ b/data/exits/bathroom.json
@@ -1,0 +1,6 @@
+{
+    "name"  : "Bathroom",
+    "long"  : "There is a dimly lit and smelly room on the north side.",
+    "short" : "North is a smelly room.",
+
+}

--- a/data/exits/cafeteria.json
+++ b/data/exits/cafeteria.json
@@ -1,0 +1,6 @@
+{
+    "name"  : "Cafeteria",
+    "long"  : "A massive room with tables and chairs and large windows smelling of old food is to the south.",
+    "short" : "South is a room smelling of old food.",
+
+}

--- a/data/exits/chemisty.json
+++ b/data/exits/chemisty.json
@@ -1,0 +1,5 @@
+{
+    "name"     : "Chemistry",
+    "long"     : "The room is rather large. There are three set of large tables on each side with a sink at each station. There are four rows of desks in the center of the room facing another large lab table and dry erase board with a teacher’s desk sitting catty corner directly across from you. On the far wall there is a cabinet filled with various glassware such as beakers, erlenmeyer flasks, and test tubes. There is a yellow cabinet next to the glassware cabinet with the word flammable across the front.",
+    "short"    : "this is a large room filled with desks, bench tops, skins, various equipment, chemicals to science experiments.",
+}

--- a/data/exits/computer.json
+++ b/data/exits/computer.json
@@ -1,0 +1,6 @@
+{
+    "name"     : "Computer Lab",
+    "long"     : "a room off of the library this room has windows on three of the four sides looking out onto the campus grounds. The fourth has a large dry erase board on it. There are several rows of tables with computers both PC’s and Mac’s in nice neat rows on them. There are chairs behind each computer for a student to sit and use the computer. At the end of each row there is a printer for each set of computers.",
+    "short"    : "a moderately sized room with rows of computers and printers. There are lots of windows here looking out onto campus.",
+
+}

--- a/data/exits/counselor_office.json
+++ b/data/exits/counselor_office.json
@@ -1,0 +1,5 @@
+{
+    "name"     : "Counselor Office",
+    "long"     : "You have entered the small and cramped counselor office.  There are books, piles of paper, boxes of Kleenex, and two ugly brown chairs facing a desk.  A bottle of Advil is on the counselor desk.  There is a computer and phone on the desk.",
+    "short"    : "The cramped counselor office with boxes of Kleenex and Advil."
+}

--- a/data/exits/detention.json
+++ b/data/exits/detention.json
@@ -1,0 +1,5 @@
+{
+    "name"     : "Detention",
+    "long"     : "A small classroom filled with empty desks in nice neat rows. There is a large desk at the very front, along with a white board. There is a very angry looking red faced teacher standing behind the desk. To your right there is a large window overlooking a parking lot. To the left there is a closed door.",
+    "short"    : "An empty room with desks in neat rows. There is a large window overlooking the empty parking lot.",
+}

--- a/data/exits/gym.json
+++ b/data/exits/gym.json
@@ -1,0 +1,5 @@
+{
+    "name"     : "Gym",
+    "long"     : "A large room with bleachers along each side. The floor is made up of wood and is heavily coated in wax. The floor has all the marking for a basketball court. There are small windows along the very top of the gym allowing some light in. The gym smells kinda funny and is very warm.",
+    "short"    : "A large room that is warm and smells funny. There are bleachers along the sides and it doubles as a basketball court."
+}

--- a/data/exits/hallway1.json
+++ b/data/exits/hallway1.json
@@ -1,0 +1,5 @@
+{
+    "name"     : "Hallway 1",
+    "long"     : "You are in a wide, brightly lit hallway.  At the north end is the detention room.  On the west is the main office.  Next to it are the trophy cases with many awards and pictures.  Across on the east side is the janitor office, also known as the broom closet.  The library is to the south.  There is a banner here about an upcoming event.",
+    "short"    : "A wide bright hall with trophies and banners.",
+}

--- a/data/exits/hallway2.json
+++ b/data/exits/hallway2.json
@@ -1,0 +1,5 @@
+{
+    "name"     : "Hallway 2",
+    "long"     : "You are in a wide, brightly lit hallway.  On the south side is the chemistry room.  At the end of the hall on the south is the music room and across on the north is the math room.  The library is at the east end.  There are lockers all along the walls of the hall.  There is a water fountain here.",
+    "short"    : "A wide bright hall with lockers and classrooms."
+}

--- a/data/exits/hallway3.json
+++ b/data/exits/hallway3.json
@@ -1,0 +1,5 @@
+{
+    "name"     : "Hallway 3",
+    "long"     : "You are in a wide, brightly lit hallway.  On the south side is the cafeteria, where there is evidence that somebody threw up their lunch, again.  The custodian mop and bucket is near the door having been abandoned after cleaning up the evidence.  On the wall is a bulletin board with menus and announcements.  The gym is to the east.  There is a bathroom on the north side across from the cafeteria.  And the library is to the west.",
+    "short"    : "A wide bright hall with mop and bucket and bulletin board."
+}

--- a/data/exits/janitor_office.json
+++ b/data/exits/janitor_office.json
@@ -1,11 +1,5 @@
 {
     "name"     : "Janitor Office",
-    "altnames" : ["custodian", "cleaning"],
     "long"     : "A neat and tidy office, you feel a little cramped in it because it is very small. There is a desk with a chair behind it. There is a coat rack with overalls hanging on it. The desk has lots of papers in nice neat organized piles, there is a picture frame on the desk of a woman holding two kids smiling. There is a calendar on the wall with the days that have already past crossed out.",
-    "short"    : "A small, neat, and tidy office. This clearly belongs to someone who loves his family.",
-    "addl"     : "A train whistle sounds across the lonely field",
-    "exits"    : {  "west"      : "Hallway 1",
-                    "east"      : "Supply Room"
-                 },
-    "visited"  : false
+    "short"    : "A small, neat, and tidy office. This clearly belongs to someone who loves his family."
 }

--- a/data/exits/library.json
+++ b/data/exits/library.json
@@ -1,0 +1,5 @@
+{
+    "name"     : "Library",
+    "long"     : "A massive room with a huge desk on the left side of the room. There are tables with chairs in various locations throughout the room for students to come and work. There are rows upon rows of shelves that hold books. There are glass displays holding various objects from different time periods. There are posters all along the walls encouraging students to read and to pick up books. There are three additional doors leading out of the library along the sides of the room.",
+    "short"    : "a massive room filled with books, computers, tables, chairs, and other items. There are three other doors along the sides."
+}

--- a/data/exits/main_office.json
+++ b/data/exits/main_office.json
@@ -1,0 +1,5 @@
+{
+    "name"     : "Main Office",
+    "long"     : "You have entered the large main office room.  The main entry/exit doors of the school are on the north.  To the east is Hallway 1.  Separating those from the office area is a big L shaped counter that is four foot tall.  There are desks and computers visible behind the counter.  There is a notebook to sign in and to sign out.  There is a phone behind the counter.  The principal office is to northwest and the counselor office to the southwest.",
+    "short"    : "The main office with a big L shaped counter."
+}

--- a/data/exits/math.json
+++ b/data/exits/math.json
@@ -1,10 +1,5 @@
 {
     "name"     : "Math Room",
-    "altnames" : ["math"],
     "long"     : "There are five columns of five rows each of desks facing a dry erase board and an overhead projector. The projector faces a screen that has been pulled down. There is a chair and small table next to it. There is a large desk on the far wall with a chair behind it. There are various posters related to math on the walls.",
-    "short"    : "A nice, neat, and orderly room with desks lined up waiting for students.",
-    "addl"     : "A train whistle sounds across the lonely field",
-    "exits"    : {  "south"     : "Hallway 2"
-                 },
-    "visited"  : false
+    "short"    : "A nice, neat, and orderly room with desks lined up waiting for students."
 }

--- a/data/exits/music.json
+++ b/data/exits/music.json
@@ -1,10 +1,5 @@
 {
     "name"     : "Music Room",
-    "altnames" : ["music", "band room"],
     "long"     : "There is a desk in the far left corner sitting catty corner with a chair behind it, this is obviously the teachers desk. Sitting in the middle of the room facing the wall are several rows of chairs in an arch. Each pair of chairs has has music stand in front of them. There is a high sitting chair in the middle of the arch with a music stand in front of it. A conductor's baton hangs from the music stand. Along the back and side walls are lockers of various shape and sizes for different instruments. There are other instruments laid out neatly and are ready to be used if wanted.",
-    "short"    : "A large room with chairs in an arch. There are lockers of various sizes at one end. There are also various music instruments out to be used.",
-    "addl"     : "A train whistle sounds across the lonely field",
-    "exits"    : {  "north"      : "Hallway 2"
-                 },
-    "visited"  : false
+    "short"    : "A large room with chairs in an arch. There are lockers of various sizes at one end. There are also various music instruments out to be used."
 }

--- a/data/exits/principal_office.json
+++ b/data/exits/principal_office.json
@@ -1,0 +1,5 @@
+{
+    "name"     : "Principal Office",
+    "long"     : "You have entered the very tidy and large principal office.  There are diplomas, certifications, and academic awards earned by the schools covering the walls.  There are many recent and older class pictures on the wall and on shelves.  There is a big, well organized desk with a big comfy executive chair behind it.  There are two large, black, plush chairs facing the desk.  There is the inevitable computer and phone on the desk, along with one box of Kleenex.",
+    "short"    : "The large and tidy principal office with awards and pictures on the wall."
+}

--- a/data/exits/supply_room.json
+++ b/data/exits/supply_room.json
@@ -1,0 +1,5 @@
+{
+    "name"     : "Supply Room",
+    "long"     : "A very small room that stores all of the cleaning equipment. It is very disorganized. The brooms and mops are in disarray. There are cleaning supplies in the bottles on the floor. There is a variety of toilet paper along the back wall. There are stains from various cleaning agents on the floors and shelves. You are afraid to touch anything because it might fall on you or the cleaning agents might spill.",
+    "short"    : "a very small disorganized room with lots of cleaning supplies."
+}

--- a/data/rooms/hallway2.json
+++ b/data/rooms/hallway2.json
@@ -6,8 +6,8 @@
     "addl"     : "A train whistle sounds across the lonely field",
     "exits"    : {  "east"      : "Library",
                     "south"     : "Chemistry",
-                    "southwest" : "Music Room",
-                    "northwest" : "Math Room"
+                    "southwest" : "Music",
+                    "northwest" : "Math"
                  },
     "visited"  : false
 }

--- a/data/rooms/hallway2.json
+++ b/data/rooms/hallway2.json
@@ -6,8 +6,8 @@
     "addl"     : "A train whistle sounds across the lonely field",
     "exits"    : {  "east"      : "Library",
                     "south"     : "Chemistry",
-                    "northwest" : "Music",
-                    "southwest" : "Math"
+                    "southwest" : "Music Room",
+                    "northwest" : "Math Room"
                  },
     "visited"  : false
 }

--- a/data/rooms/math.json
+++ b/data/rooms/math.json
@@ -1,6 +1,6 @@
 {
-    "name"     : "Math Room",
-    "altnames" : ["math"],
+    "name"     : "Math",
+    "altnames" : ["math room"],
     "long"     : "There are five columns of five rows each of desks facing a dry erase board and an overhead projector. The projector faces a screen that has been pulled down. There is a chair and small table next to it. There is a large desk on the far wall with a chair behind it. There are various posters related to math on the walls.",
     "short"    : "A nice, neat, and orderly room with desks lined up waiting for students.",
     "addl"     : "A train whistle sounds across the lonely field",

--- a/data/rooms/music.json
+++ b/data/rooms/music.json
@@ -1,6 +1,6 @@
 {
-    "name"     : "Music Room",
-    "altnames" : ["music", "band room"],
+    "name"     : "Music",
+    "altnames" : ["music room", "band room"],
     "long"     : "There is a desk in the far left corner sitting catty corner with a chair behind it, this is obviously the teachers desk. Sitting in the middle of the room facing the wall are several rows of chairs in an arch. Each pair of chairs has has music stand in front of them. There is a high sitting chair in the middle of the arch with a music stand in front of it. A conductor's baton hangs from the music stand. Along the back and side walls are lockers of various shape and sizes for different instruments. There are other instruments laid out neatly and are ready to be used if wanted.",
     "short"    : "A large room with chairs in an arch. There are lockers of various sizes at one end. There are also various music instruments out to be used.",
     "addl"     : "A train whistle sounds across the lonely field",


### PR DESCRIPTION
Exit data is setting up for long and short descriptions of exits as written in the spec.  Room data bug fixes are for swapping the position of Math and Music compared to project plan map, and fixing the room names of Math and Music to navigate the map.