### PR TITLE
add room features and refine methods for drop/take

### DIFF
--- a/data/rooms/bathroom.json
+++ b/data/rooms/bathroom.json
@@ -1,11 +1,18 @@
 {
     "name"     : "Bathroom",
-    "altnames" : ["bathroom","bath room","potty", "head"],
-    "long"     : "A dimly lit room. The floor is really sticky and the smell is atrocious. There is water on the floor from where one of the toilets overflowed. There are four stalls on your right all with doors. The stall at the very end has a do not use sign on it. To your left there are three sinks with soap dispensers, all without soap. There are no mirrors in the bathroom. The floor tile is a sickly yellow looking color.",
+    "altnames" : ["bathroom", "bath room", "potty", "head"],
+    "long"     : "A dimly lit room. The floor is really sticky and the smell is atrocious. There are four stalls and thankfully all have doors. The stall at the very end has a sign on it. There are sinks with soap dispensers, many appear to have no soap. There are no mirrors in the bathroom.",
     "short"    : "A sad and pathetic looking room, it smells horrible and you really do not want to be in here.",
     "addl"     : "A train whistle sounds across the lonely field",
     "exits"    : {  "south"     : "Hallway 3"
                  },
     "items"    : [],
+    "features" : {  "sign" : "The sign at the far end reads OUT OF ORDER, and there is some water on the floor. The stall closest to the door seems ok.",
+                    "stall" : "The sign at the far end reads OUT OF ORDER, and there is some water on the floor. The stall closest to the door seems ok.",
+                    "stalls" : "The sign at the far end reads OUT OF ORDER, and there is some water on the floor. The stall closest to the door seems ok.",
+                    "soap" : "The sink closest to the door has soap in its soap dispenser.",
+                    "sink" : "The sink closest to the door has soap in its soap dispenser.",
+                    "sinks" : "The sink closest to the door has soap in its soap dispenser."
+                 },
     "visited"  : false
 }

--- a/data/rooms/cafeteria.json
+++ b/data/rooms/cafeteria.json
@@ -1,11 +1,17 @@
 {
     "name"     : "Cafeteria",
     "altnames" : ["cafeteria", "cafe", "Cafe", "Lunch Room", "lunchroom"],
-    "long"     : "A massive room with tables and chairs in neat and orderly rows. There is food and food trays at various spots suggesting that students did not clean up after themselves. To your left there are two cash registers for students to pay for lunches. To the right and straight in front of you there is a wall of large windows looking outside. There is no one in sight and the room smells of old forgotten food.",
+    "long"     : "A massive room with tables and chairs in neat and orderly rows. There is food and food trays at various spots suggesting that students did not clean up after themselves. There are two cash registers for students to pay for lunches. There is a wall of large windows looking outside. There is no one in sight and the room smells of old forgotten food.",
     "short"    : "A room smelling of old food, but full of tables in orderly rows and windows.",
     "addl"     : "A train whistle sounds across the lonely field",
     "exits"    : {  "north"     : "Hallway 3"
                  },
     "items"    : ["water bottle"],
+    "features" : {  "table" : "On closer inspection, most tables were wiped and sanitized. Only a few tables near the front are messy. Maybe a group elsewhere in the building came in after hours and made this mess.",
+                    "tables" : "On closer inspection, most tables were wiped and sanitized. Only a few tables near the front are messy. Maybe a group elsewhere in the building came in after hours and made this mess.",
+                    "cash" : "You find a small refrigerator beside the cash register used to cool water.",
+                    "register" : "You find a small refrigerator beside the cash register used to cool water.",
+                    "cash register" : "You find a small refrigerator beside the cash register used to cool water."
+                 },
     "visited"  : false
 }

--- a/data/rooms/chemisty.json
+++ b/data/rooms/chemisty.json
@@ -1,11 +1,23 @@
 {
     "name"     : "Chemistry",
     "altnames" : ["chemistry", "chem"],
-    "long"     : "The room is rather large. There are three set of large tables on each side with a sink at each station. There are four rows of desks in the center of the room facing another large lab table and dry erase board with a teacher’s desk sitting catty corner directly across from you. On the far wall there is a cabinet filled with various glassware such as beakers, erlenmeyer flasks, and test tubes. There is a yellow cabinet next to the glassware cabinet with the word flammable across the front.",
+    "long"     : "The room is rather large. There are three set of large tables on each side with a sink at each station. There are four rows of desks in the center of the room facing another large lab table and teacher desk with a dry erase board on the wall. On the far wall there is a cabinet filled with various glassware such as beakers, erlenmeyer flasks, and test tubes. There is a yellow cabinet next to the glassware cabinet with the word FLAMMABLE across the front.",
     "short"    : "This is a large room filled with desks, bench tops, skins, various equipment, chemicals to science experiments.",
     "addl"     : "A train whistle sounds across the lonely field",
     "exits"    : {  "north"     : "Hallway 2"
                  },
     "items"    : ["camera"],
+    "features" : {  "table" : "Nothing exciting on the tables.",
+                    "tables" : "Nothing exciting on the tables.",
+                    "lab table" : "There is a camera and a camera manual here.",
+                    "desk" : "The desks are all empty and tidy.",
+                    "desks" : "The desks are all empty and tidy.",
+                    "board" : "The days reading, homework, and lab assignments are listed. Everything else was erased.",
+                    "dry erase board" : "The days reading, homework, and lab assignments are listed. Everything else was erased.",
+                    "cabinet" : "In addition to the glassware and chemicals, there is a shelf with an empty camera box.",
+                    "yellow cabinet" : "In addition to the glassware and chemicals, there is a shelf with an empty camera box.",
+                    "glassware cabinet" : "In addition to the glassware and chemicals, there is a shelf with an empty camera box.",
+                    "glassware" : "In addition to the glassware and chemicals, there is a shelf with an empty camera box."
+                 },
     "visited"  : false
 }

--- a/data/rooms/computer.json
+++ b/data/rooms/computer.json
@@ -1,11 +1,24 @@
 {
     "name"     : "Computer Lab",
-    "altnames" : ["computer","computerlab","lab"],
-    "long"     : "A room off of the library this room has windows on three of the four sides looking out onto the campus grounds. The fourth has a large dry erase board on it. There are several rows of tables with computers both PC’s and Mac’s in nice neat rows on them. There are chairs behind each computer for a student to sit and use the computer. At the end of each row there is a printer for each set of computers.",
+    "altnames" : ["computer", "computerlab", "lab"],
+    "long"     : "A room off of the library this room has windows on three of the four sides looking out onto the campus grounds. The fourth has a large dry erase board on it. There are several rows of tables with computers both PCs and Macs in nice neat rows on them. There are chairs behind each computer for a student to sit and use the computer. At the end of each row there is a printer for each set of computers.",
     "short"    : "A moderately sized room with rows of computers and printers. There are lots of windows here looking out onto campus.",
     "addl"     : "A train whistle sounds across the lonely field",
     "exits"    : {  "north"     : "Library"
                  },
     "items"    : ["SD card"],
+    "features" : {  "table" : "Nothing exciting on the tables.",
+                    "tables" : "Nothing exciting on the tables.",
+                    "printer" : "All the printers are turned off for the day except the one for the back row has a printout about uploading videos to YouTube.",
+                    "printers" : "All the printers are turned off for the day except the one for the back row has a printout about uploading videos to YouTube.",
+                    "PC" : "All the PCs are turned off for the day.",
+                    "PCs" : "All the PCs are turned off for the day.",
+                    "Mac" : "All the Macs are turned off for the day, except for one in the back corner of the room.",
+                    "Macs" : "All the Macs are turned off for the day, except for one in the back corner of the room.",
+                    "desk" : "The desks are all empty and tidy.",
+                    "desks" : "The desks are all empty and tidy.",
+                    "board" : "The days reading, homework, and lab assignments are listed. An example program is written.",
+                    "dry erase board" : "The days reading, homework, and lab assignments are listed. An example program is written."
+                 },
     "visited"  : false
 }

--- a/data/rooms/counselor_office.json
+++ b/data/rooms/counselor_office.json
@@ -7,5 +7,12 @@
     "exits"    : {  "east"      : "Main Office"
                  },
     "items"    : [],
+    "features" : {  "Advil" : "This is extra strength Advil",
+                    "advil" : "This is extra strength Advil",
+                    "Kleenex" : "All oversized boxes of Kleenex with lotion protection to calm a sore nose",
+                    "kleenex" : "All oversized boxes of Kleenex with lotion protection to calm a sore nose",
+                    "computer" : "The computer has many open windows on the screen concerning student records and case files.",
+                    "books" : "Many titles on caring and helping kids. The reader must care for their students."
+                 },
     "visited"  : false
 }

--- a/data/rooms/detention.json
+++ b/data/rooms/detention.json
@@ -7,5 +7,9 @@
     "exits"    : {  "south"      : "Hallway 1"
                  },
     "items"    : ["backpack"],
+    "features" : {  "board" : "The white board says: You are in DETENTION so BE QUIET and DO your homework. Do NOT forget to take your homework and books when you leave!!",
+                    "white board" : "The white board says: You are in DETENTION so BE QUIET and DO your homework. Do NOT forget to take your homework and books when you leave!!",
+                    "door" : "The door is closed. You can see an empty hallway through the window."
+                 },
     "visited"  : false
 }

--- a/data/rooms/gym.json
+++ b/data/rooms/gym.json
@@ -1,11 +1,14 @@
 {
     "name"     : "Gym",
     "altnames" : ["gym", "gymnasium", "Gymnasium", "PE", "pe"],
-    "long"     : "A large room with bleachers along each side. The floor is made up of wood and is heavily coated in wax. The floor has all the marking for a basketball court. There are small windows along the very top of the gym allowing some light in. The gym smells kinda funny and is very warm.",
+    "long"     : "A large room with bleachers along each side. The floor is made up of wood. The floor has all the markings for a basketball court. There are small windows along the very top of the gym allowing some light in. The gym smells kinda funny and is very warm.",
     "short"    : "A large room that is warm and smells funny. There are bleachers along the sides and it doubles as a basketball court.",
     "addl"     : "A train whistle sounds across the lonely field",
     "exits"    : {  "west"      : "Hallway 3"
                  },
     "items"    : [],
+    "features" : {  "floor" : "The wood floor is heavily coated in wax for protection. There are dodgeballs scattered about.",
+                    "bleachers" : "The bottom row or two of the bleachers have team jackets and team sweats strewn about. There are some dodgeballs thrown around."
+                 },
     "visited"  : false
 }

--- a/data/rooms/hallway1.json
+++ b/data/rooms/hallway1.json
@@ -10,5 +10,13 @@
                     "west"      : "Main Office"
                  },
     "items"    : [],
+    "features" : {  "banner" : "The event is announcement of Dodgeball Tryouts TODAY !! and the start of Dodgeball season in two weeks !!!",
+                    "event" : "The event is announcement of Dodgeball Tryouts TODAY !! and the start of Dodgeball season in two weeks !!!",
+                    "trophies" : "The trophies and awards are across the range of student activities, sporting, music, and academic.",
+                    "trophy case" : "The trophies and awards are across the range of student activities, sporting, music, and academic.",
+                    "awards" : "The trophies and awards are across the range of student activities, sporting, music, and academic.",
+                    "ribbons" : "The trophies and awards are across the range of student activities, sporting, music, and academic.",
+                    "pictures" : "Pictures documenting the many trophies and awards of student activities."
+                 },
     "visited"  : false
 }

--- a/data/rooms/hallway2.json
+++ b/data/rooms/hallway2.json
@@ -10,5 +10,8 @@
                     "northwest" : "Math"
                  },
     "items"    : [],
+    "features" : {  "lockers" : "The lockers are newly painted for the school year but dings and dents and old markings are evident on closer examination.",
+                    "water fountain" : "Freshly cleaned by the staff, this water fountain provides clean, cold water."
+                 },
     "visited"  : false
 }

--- a/data/rooms/hallway3.json
+++ b/data/rooms/hallway3.json
@@ -10,5 +10,10 @@
                     "west"      : "Library"
                  },
     "items"    : [],
+    "features" : {  "mop" : "Smells of strong cleaning solutions",
+                    "bucket" : "A bucket having a strong cleaning solution.",
+                    "evidence" : "This is ... well ... you really do not want to know, but it has been cleaned up with a disinfecting agent on top",
+                    "bulletin board" : "There is a prominent announcement in big bold letters about Dodgeball tryouts TODAY!"
+                 },
     "visited"  : false
 }

--- a/data/rooms/janitor_office.json
+++ b/data/rooms/janitor_office.json
@@ -1,12 +1,15 @@
 {
     "name"     : "Janitor Office",
     "altnames" : ["Janitor", "janitor office", "janitoroffice", "janitor", "custodian"],
-    "long"     : "A neat and tidy office, you feel a little cramped in it because it is very small. There is a desk with a chair behind it. There is a coat rack with overalls hanging on it. The desk has lots of papers in nice neat organized piles, there is a picture frame on the desk of a woman holding two kids smiling. There is a calendar on the wall with the days that have already past crossed out.",
+    "long"     : "A neat and tidy office, you feel a little cramped in it because it is very small. There is a desk with a chair behind it. There is a coat rack with overalls hanging on it. The desk has lots of papers in nice neat organized piles, and a big picture. There is a calendar on the wall.",
     "short"    : "A small, neat, and tidy office. This clearly belongs to someone who loves his family.",
     "addl"     : "A train whistle sounds across the lonely field",
     "exits"    : {  "west"      : "Hallway 1",
                     "east"      : "Supply Room"
                  },
     "items"    : [],
+    "features" : {  "picture" : "A family picture of a woman holding two kids smiling.",
+                    "calendar" : "Days that have already passed are crossed out on this calendar."
+                 },
     "visited"  : false
 }

--- a/data/rooms/library.json
+++ b/data/rooms/library.json
@@ -1,7 +1,7 @@
 {
     "name"     : "Library",
     "altnames" : ["library", "libary", "bookroom", "studyhall"],
-    "long"     : "A massive room with a huge desk on the left side of the room. There are tables with chairs in various locations throughout the room for students to come and work. There are rows upon rows of shelves that hold books. There are glass displays holding various objects from different time periods. There are posters all along the walls encouraging students to read and to pick up books. There are three additional doors leading out of the library along the sides of the room.",
+    "long"     : "A massive room with a huge desk to one side of the room. There are tables with chairs in various locations throughout the room for students to come and work. There are rows upon rows of shelves that hold books. There are glass displays holding various objects from different time periods. There are posters all along the walls encouraging students to read and to pick up books. There are three additional doors leading out of the library along the sides of the room.",
     "short"    : "A massive room filled with books, tables, chairs, and items for study.",
     "addl"     : "A train whistle sounds across the lonely field",
     "exits"    : {  "north"     : "Hallway 1",
@@ -9,5 +9,10 @@
                     "east"      : "Hallway 3"
                  },
     "items"    : ["book"],
+    "features" : {  "desk" : "There are books to be shelved here, and books on hold to be checked out. There are special edition books here on reserve.",
+                    "displays" : "These are historical objects to entice and encourage student interest in reading.",
+                    "glass displays" : "These are historical objects to entice and encourage student interest in reading.",
+                    "posters" : "Many alternate strategies are employed by the posters to spark reading, biographical, science, arts, sports, history, and more."
+                 },
     "visited"  : false
 }

--- a/data/rooms/main_office.json
+++ b/data/rooms/main_office.json
@@ -10,5 +10,11 @@
                     "southwest" : "Counselor Office"
                  },
     "items"    : ["cellphone"],
+    "features" : {  "exit" : "The main entry/exit doors are locked since it is after hours.",
+                    "main exit" : "The main entry/exit doors are locked since it is after hours.",
+                    "main entry" : "The main entry/exit doors are locked since it is after hours.",
+                    "entry" : "The main entry/exit doors are locked since it is after hours.",
+                    "notebook" : "Many names of parents, volunteers, and a few tardy students have signed the notebook."
+                 },
     "visited"  : false
 }

--- a/data/rooms/math.json
+++ b/data/rooms/math.json
@@ -7,5 +7,14 @@
     "exits"    : {  "south"     : "Hallway 2"
                  },
     "items"    : ["calculator"],
+    "features" : {  "table" : "Someone left a calculator.",
+                    "small table" : "Someone left a calculator.",
+                    "desk" : "The desks are all empty and tidy.",
+                    "desks" : "The desks are all empty and tidy.",
+                    "board" : "The days homework is listed. Example problems are worked on the board.",
+                    "dry erase board" : "The days homework is listed. Example problems are worked on the board.",
+                    "poster" : "Some posters are more like infographics for how to solve problems. Some are biographies of famous mathematicians.",
+                    "posters" : "Some posters are more like infographics for how to solve problems. Some are biographies of famous mathematicians."
+                 },
     "visited"  : false
 }

--- a/data/rooms/music.json
+++ b/data/rooms/music.json
@@ -1,11 +1,18 @@
 {
     "name"     : "Music",
     "altnames" : ["music", "music room", "Music Room", "band room", "band"],
-    "long"     : "There is a desk in the far left corner sitting catty corner with a chair behind it, this is obviously the teachers desk. Sitting in the middle of the room facing the wall are several rows of chairs in an arch. Each pair of chairs has has music stand in front of them. There is a high sitting chair in the middle of the arch with a music stand in front of it. A conductor's baton hangs from the music stand. Along the back and side walls are lockers of various shape and sizes for different instruments. There are other instruments laid out neatly and are ready to be used if wanted.",
+    "long"     : "There is a desk in the corner sitting catty corner with a chair behind it, It is obviously the teachers desk. Sitting in the middle of the room facing the wall are several rows of chairs in an arch. Each pair of chairs has has music stand in front of them. There is a high sitting chair in the middle of the arch with a music stand in front of it. A conductor baton hangs from the music stand. Along the back and side walls are lockers of various shapes and sizes for different instruments. There are other instruments laid out neatly and are ready to be used if wanted.",
     "short"    : "A room with chairs in an arch, lockers of various sizes, and music instruments.",
     "addl"     : "A train whistle sounds across the lonely field",
     "exits"    : {  "north"      : "Hallway 2"
                  },
     "items"    : ["piccolo"],
+    "features" : {  "baton" : "The baton seems unusually heavy and made of an exotic material. It is not cheap plastic. The owner must be accomplished.",
+                    "conductor baton" : "The baton seems unusually heavy and made of an exotic material. It is not cheap plastic. The owner must be accomplished.",
+                    "instrument" : "All instruments are kept polished and shiny even though they have their share of dents. All except an old piccolo in the back corner.",
+                    "instruments" : "All instruments are kept polished and shiny even though they have their share of dents. All except an old piccolo in the back corner.",
+                    "locker" : "The lockers are all need a bit of cleaning. This room is heavily used.",
+                    "lockers" : "The lockers are all need a bit of cleaning. This room is heavily used."
+                 },
     "visited"  : false
 }

--- a/data/rooms/principal_office.json
+++ b/data/rooms/principal_office.json
@@ -7,5 +7,11 @@
     "exits"    : {  "east"      : "Main Office"
                  },
     "items"    : [],
+    "features" : {  "pictures" : "The pictures are all school related class pictures, awards pictures, event pictures, and the like.",
+                    "diplomas" : "The diplomas document the academic accomplishments of the principal.",
+                    "certifications" : "The certifications documents the accomplishments of the principal and the school and its students and staff.",
+                    "awards" : "The school and students awards earned here are numerous. This must be an excellent school.",
+                    "desk" : "Not much to see on the desk because it is very clean and tidy"
+                 },
     "visited"  : false
 }

--- a/data/rooms/supply_room.json
+++ b/data/rooms/supply_room.json
@@ -1,11 +1,17 @@
 {
     "name"     : "Supply Room",
     "altnames" : ["supply room", "supplyroom", "supply", "supplies"],
-    "long"     : "A very small room that stores all of the cleaning equipment. It is very disorganized. The brooms and mops are in disarray. There are cleaning supplies in the bottles on the floor. There is a variety of toilet paper along the back wall. There are stains from various cleaning agents on the floors and shelves. You are afraid to touch anything because it might fall on you or the cleaning agents might spill.",
-    "short"    : "A very small disorganized room with lots of cleaning supplies.",
+    "long"     : "A very small room that stores all of the cleaning equipment and associated supplies. It is very well organized like the office you just walked through to get here. There are cleaning supplies in bottles on the floor. There is a variety of paper products along the back of many shelves.",
+    "short"    : "A very small room with lots of cleaning equipment and supplies.",
     "addl"     : "A train whistle sounds across the lonely field",
     "exits"    : {  "west"      : "Janitor Office"
                  },
     "items"    : ["duct tape"],
+    "features" : {  "supplies" : "Besides cleaning and paper products, you see oddly enough, duct tape.",
+                    "paper" : "In front of paper products are rolls of duct tape.",
+                    "paper products" : "In front of paper products are rolls of duct tape.",
+                    "floor" : "There are stains from various cleaning supplies that accidentally leaked.",
+                    "shelves" : "There are stains from various cleaning supplies that accidentally leaked."
+                 },
     "visited"  : false
 }

--- a/data_format.py
+++ b/data_format.py
@@ -18,10 +18,10 @@ DELAY = 0       # make this smaller for a faster scroll
 MAXLEN = 80     # maximum line length to print
 
 '''
-    Build Exit objects for the game from JSON files found in a directory.
-    Read json files in exits data directory and create an Exit object from each.
-    Return a list of Exit objects.
-    '''
+Build Exit objects for the game from JSON files found in a directory.
+Read json files in exits data directory and create an Exit object from each.
+Return a list of Exit objects.
+'''
 class ExitBuilder:
     
     def __init__(self):
@@ -112,6 +112,7 @@ class Room:
         self.addl        = props["addl"]         # additional something that happens when in the room
         self.exits       = props["exits"]        # dictionary of exit directions and name of the room
         self.items       = props["items"]        # list of items in the room
+        self.features    = props["features"]     # dictionary of room features
         self.visited     = props["visited"]      # STATE - True/False - has player visited the room
         self.save()                              # save the new object just initialized
 
@@ -136,6 +137,10 @@ class Room:
             util.scroll3(DELAY, MAXLEN, "{} : {}".format(exit, room))
         for item in self.get_items():
             util.scroll3(DELAY, MAXLEN, "Item:    {}".format(item))
+        features = self.get_features()
+        for name, desc in features.items():
+            util.scroll3(DELAY, MAXLEN, "Feature Name : {}".format(name))
+            util.scroll3(DELAY, MAXLEN, "Feature Desc : {}".format(desc))
         util.scroll3(DELAY, MAXLEN, "Visited:  {}".format(self.get_visited()))
 
     def get_name(self):
@@ -154,13 +159,19 @@ class Room:
         return self.addl
 
     def get_exitdirs(self):
-        return self.exitdirs
+        return self.exits.keys()
+
+    def get_exitrooms(self):
+        return self.exits.values()
 
     def get_exits(self):
         return self.exits
 
     def get_items(self):
         return self.items
+
+    def get_features(self):
+        return self.features
 
     def drop_item(self, value):
         self.items.append(value)
@@ -381,7 +392,7 @@ class Player:
     def get_items(self):
         return self.items
 
-    def add_item(self, value):
+    def take_item(self, value):
         self.items.append(value)
 
     def drop_item(self, value):
@@ -418,9 +429,9 @@ def main():
 
     player.set_name("Pat")
     player.set_location("Main Office")
-    player.add_item("metronome")
-    player.add_item("calculator")
-    player.add_item("master key")
+    player.take_item("metronome")
+    player.take_item("calculator")
+    player.take_item("master key")
 
     player.print_me()
 
@@ -437,13 +448,6 @@ def main():
     for character in character_list:
         character.print_me()
 
-    quit()
-    quit()
-    quit()
-    quit()
-    quit()
-    quit()
-
     util.scroll(DELAY, MAXLEN, "-" * 80)
     util.scroll(DELAY, MAXLEN, "for thing in list print thing.attributes")
     util.scroll(DELAY, MAXLEN, "-" * 80)
@@ -454,11 +458,19 @@ def main():
         print("Long:   ", room.get_long())
         print("Short:  ", room.get_short())
         print("Addl:   ", room.get_addl())
+        for dir in room.get_exitdirs():
+            print("Exit Dir:   ", dir)
+        for nextroom in room.get_exitrooms():
+            print("Next Room:  ", nextroom)
         exits = room.get_exits()
         for exit, nextroom in exits.items():
             print("Exit Direction : {}".format(exit))
             print("Exit Next Room : {}".format(nextroom))
             print("{} : {}".format(exit, nextroom))
+        features = room.get_features()
+        for name, desc in features.items():
+            print("Feature Name : {}".format(name))
+            print("Feature Desc : {}".format(desc))
         print("Visited: ", room.get_visited())
 
     for item in item_list:


### PR DESCRIPTION
Room features were a requirement missing from the mid point check.  This pull request adds them.

Also, this pull  request refines the drop/take of an item.  For example, if a player wants to take an item, then the take method is used in both room class and player class.  In room class take remove the item from the list where in player class take add the item to the list.  So you must take and take in both to accomplish a UI take.  Similar for drop.